### PR TITLE
feat: Make XNode field `slots` slab-friendly and cacheline-aligned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smallvec = "*"
+smallvec = "1.13.1"
 
 [features]
 default = []
 std = []
+# 内存排布对slab分配器更友好，内存用量更低
+slab-friendly = []


### PR DESCRIPTION
- 原本的XNode大小为544字节，对采用slab分配器的内核而言不友好，会实际分配1K。优化后实际分配576字节
- 由于原本xarray的slots数组不是cacheline对齐的，因此速度慢。换了之后benchmark性能有提升

启用feature： `slab-friendly`即可开启本优化

